### PR TITLE
Add github workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,47 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+name: Build container image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    name: Build container image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # Action reference: https://github.com/actions/checkout
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      # Action reference: https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU (for docker buildx)
+        uses: docker/setup-qemu-action@v1
+
+      # Action reference: https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # Action reference: https://github.com/docker/login-action
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Action reference: https://github.com/docker/build-push-action
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/nfs-server:latest


### PR DESCRIPTION
This will build (with multi-arch support) and publish this repo﻿ to Github Packages (ghcr.io).  If you want this to push to quay.io/redhat-developer also (or instead), then that can be arranged by using a robot account in Quay and secrets in Github.
